### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/games/minecraft/convert-world.mdx
+++ b/games/minecraft/convert-world.mdx
@@ -25,7 +25,7 @@ This Minecraft converstion tool has been developed by the [HiveMC](https://playh
 ## Converting a world with Chunker
 
   1. Visit the [chunker.app](https://chunker.app/) website.
-  2. Save your Minecraft world folder ([Java](https://minecraft.fandom.com/wiki/Java_Edition)) or .mcworld file ([Bedrock](https://minecraft.fandom.com/wiki/Bedrock_Edition)).
+  2. Save your Minecraft world folder ([Java](https://minecraft.wiki/w/Java_Edition)) or .mcworld file ([Bedrock](https://minecraft.wiki/w/Bedrock_Edition)).
   3. Upload the folder or archive of the world you wish to convert to Chunker.
   4. Click the "**Start Upload**" button.
   4. Select the world version/format you want to convert to.


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates both fandom links accordingly.